### PR TITLE
never raise exception on empty field

### DIFF
--- a/src/main/java/org/xbib/elasticsearch/action/langdetect/TransportLangdetectAction.java
+++ b/src/main/java/org/xbib/elasticsearch/action/langdetect/TransportLangdetectAction.java
@@ -64,12 +64,8 @@ public class TransportLangdetectAction extends TransportSingleCustomOperationAct
     }
 
     @Override
-    protected LangdetectResponse shardOperation(LangdetectRequest request, int shardId) throws ElasticsearchException {
-        try {
-            List<Language> langs = detector.detectAll(request.getText().toUtf8());
-            return new LangdetectResponse(langs);
-        } catch (LanguageDetectionException e) {
-            throw new ElasticsearchException(e.getMessage(), e);
-        }
+    protected LangdetectResponse shardOperation(LangdetectRequest request, int shardId) {
+        List<Language> langs = detector.detectAll(request.getText().toUtf8());
+        return new LangdetectResponse(langs);
     }
 }

--- a/src/main/java/org/xbib/elasticsearch/common/langdetect/Detector.java
+++ b/src/main/java/org/xbib/elasticsearch/common/langdetect/Detector.java
@@ -185,9 +185,8 @@ public class Detector extends AbstractLifecycleComponent<Detector> {
      * the highest probability.
      *
      * @return detected language name which has most probability.
-     * @throws LanguageDetectionException
      */
-    public String detect(String text) throws LanguageDetectionException {
+    public String detect(String text) {
         List<Language> probabilities =
                 detectAll(text.replaceAll(word.pattern(), " "));
         //detectAll(normalize(text));
@@ -197,22 +196,24 @@ public class Detector extends AbstractLifecycleComponent<Detector> {
         return UNKNOWN_LANG;
     }
 
-    public List<Language> detectAll(String text) throws LanguageDetectionException {
+    public List<Language> detectAll(String text) {
         return sortProbability(detectBlock(/*normalize(text)*/text.replaceAll(word.pattern(), " ")));
     }
 
-    private double[] detectBlock(String text) throws LanguageDetectionException {
+    private static final double[] NO_DOUBLE = {};
+
+    private double[] detectBlock(String text) {
         //text = clean(text);
         List<String> ngrams = extractNGrams(text);
+        // we should allow empty text field, anyway never raise an exception during indexing process
+        // since UNKNOWN_LANG exists
         if (ngrams.isEmpty()) {
-            throw new LanguageDetectionException("no features in text");
+            return NO_DOUBLE;
         }
         double[] langprob = new double[langlist.size()];
         Random rand = new Random();
-        Long seed = 0L;
-        if (seed != null) {
-            rand.setSeed(seed);
-        }
+        rand.setSeed(0L);
+
         for (int t = 0; t < n_trial; ++t) {
             double[] prob = initProbability();
             double a = this.alpha + rand.nextGaussian() * ALPHA_WIDTH;

--- a/src/test/java/org/xbib/elasticsearch/common/langdetect/DetectorTest.java
+++ b/src/test/java/org/xbib/elasticsearch/common/langdetect/DetectorTest.java
@@ -9,7 +9,9 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class DetectorTest extends Assert {
-    
+
+    private static final String UNKNOWN_LANG = "unknown";
+
     private static final String TRAINING_EN = "a a a b b c c d e";
 
     private static final String TRAINING_FR = "a b b c c c d d d";
@@ -46,27 +48,27 @@ public class DetectorTest extends Assert {
     }
 
     @Test
-    public void testDetector1() throws LanguageDetectionException {
+    public void testDetector1() {
         assertEquals(detect.detect("a"), "en");
     }
 
     @Test
-    public void testDetector2() throws LanguageDetectionException {
+    public void testDetector2() {
         assertEquals(detect.detect("b d"), "fr");
     }
 
     @Test
-    public void testDetector3() throws LanguageDetectionException {
+    public void testDetector3() {
         assertEquals(detect.detect("d e"), "en");
     }
 
     @Test
-    public void testDetector4() throws LanguageDetectionException {
+    public void testDetector4() {
         assertEquals(detect.detect("\u3042\u3042\u3042\u3042a"), "ja");
     }
 
     @Test
-    public void testLangList() throws LanguageDetectionException {
+    public void testLangList() {
         List<String> langList = detect.getLangList();
         assertEquals(langList.size(), 3);
         assertEquals(langList.get(0), "en");
@@ -74,9 +76,9 @@ public class DetectorTest extends Assert {
         assertEquals(langList.get(2), "ja");
     }
 
-    @Test(expectedExceptions = LanguageDetectionException.class)
-    public void testPunctuation() throws LanguageDetectionException {
-        assertEquals(detect.detect("..."), "none");
+    @Test
+    public void testPunctuation() {
+        assertEquals(detect.detect("..."), UNKNOWN_LANG);
     }
 
 


### PR DESCRIPTION
related issue #7 from @tintin04

If the field is empty an exception was raised, and it stops indexing in a bulk process. If a field hasn't any text, it hasn't any language, but raising an exception doesn't seem to be the right way to do it.

My commit return "unknown" for empty field, but we might return an empty string, don't you think ?
