### PR TITLE
Bad link to plugin artefact

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ zh-tw
 
 ## Installation Elasticsearch 2.x
 
-    ./bin/plugin install https://github.com/jprante/elasticsearch-langdetect/releases/download/2.3.3.0/elasticsearch-langdetect-2.3.3.0-plugin.zip
+    ./bin/plugin install https://github.com/jprante/elasticsearch-langdetect/archive/2.3.3.0.zip
 
 ## Installation Elasticsearch 1.x
 


### PR DESCRIPTION
Form version 2.2.0.1 there are no releases on github : https://github.com/jprante/elasticsearch-langdetect/releases
Instead of artefacts are created by tags.