### PR TITLE
Adds support for ES 5.6.5

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -89,6 +89,7 @@ Here is a list of languages code recognized:
 [frame="all"]
 |===
 | Plugin version | Elasticsearch version | Release date
+| 5.6.0.0        | 5.6.5 | Dec 12, 2017
 | 5.4.0.2        | 5.4.0 | Jun  8, 2017
 | 5.4.0.1        | 5.4.0 | May 30, 2017
 | 5.4.0.0        | 5.4.0 | May 10, 2017

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
 group = org.xbib.elasticsearch.plugin
 name = elasticsearch-langdetect
-version = 5.4.0.2
+version = 5.6.0.0
 
-elasticsearch.version = 5.4.0
-log4j.version = 2.8.2
+elasticsearch.version = 5.6.5
+log4j.version = 2.9.1
 junit.version = 4.12
 asciidoclet.version = 1.5.4
 wagon.version = 2.12


### PR DESCRIPTION
The version of the `log4j` lib has been updated too.

Related issue https://github.com/jprante/elasticsearch-langdetect/issues/77